### PR TITLE
Add new module setting for show the companion list only to GM

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -52,6 +52,10 @@
             "restrictOwned":{
                 "title": "Only Owned Actors",
                 "hint": "Restrict the companion list to only show owned companions actors."
+            },
+            "restrictOnlyGM": {
+              "title": "Only GM can see Companion button",
+              "hint": "Restrict the companion list to GMs only"
             }
         }
     }

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -63,6 +63,14 @@ Hooks.once("init", async function () {
     type: Boolean,
     default: false,
   });
+  game.settings.register(AECONSTS.MN, "restrictOnlyGM", {
+    name: game.i18n.localize(`AE.settings.restrictOnlyGM.title`),
+    hint: game.i18n.localize(`AE.settings.restrictOnlyGM.hint`),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+  });
 });
 
 Hooks.once("ready", async function () {
@@ -83,10 +91,10 @@ Hooks.once("ready", async function () {
     });
   }
   AECONSTS.animations = Object.keys(AECONSTS.animations).sort().reduce(
-    (obj, key) => { 
-      obj[key] = AECONSTS.animations[key]; 
+    (obj, key) => {
+      obj[key] = AECONSTS.animations[key];
       return obj;
-    }, 
+    },
     {}
   );
   //new CompanionManager().render(true)
@@ -94,6 +102,12 @@ Hooks.once("ready", async function () {
 
 Hooks.on("getActorSheetHeaderButtons", (app, buttons) => {
   if(game.settings.get(AECONSTS.MN, "hidebutton")) return;
+
+  const restrictedOnlyGM = game.settings.get(AECONSTS.MN, 'restrictOnlyGM');
+  if (restrictedOnlyGM && !game.user?.isGM) {
+    return;
+  }
+
   buttons.unshift({
     icon: "fas fa-users",
     class: "open-cm",


### PR DESCRIPTION
Some players like this module too much, with this PR I propose to add a property to allow GMs to take control of the tool or at least hide the button on the header sheet.