### PR TITLE
Only use default evocations for english locale

### DIFF
--- a/scripts/autoevocations/dnd5e.js
+++ b/scripts/autoevocations/dnd5e.js
@@ -3,7 +3,8 @@ Hooks.once("ready", async function () {
         game.automatedevocations = {};
         game.automatedevocations[game.system.id] = {};
     }
-    if (game.system.id == "dnd5e") {
+    const lang = await game.settings.get("core", "language");
+    if (game.system.id == "dnd5e" && lang === "en") {
         game.automatedevocations.dnd5e = {
             "Arcane Hand": [
                 {

--- a/scripts/autoevocations/pf2e.js
+++ b/scripts/autoevocations/pf2e.js
@@ -3,7 +3,8 @@ Hooks.once("ready", async function () {
       game.automatedevocations = {};
       game.automatedevocations[game.system.id] = {};
     }
-   if(game.system.id == "pf2e"){
+   const lang = await game.settings.get("core", "language");
+   if(game.system.id == "pf2e" && lang === "en"){
     game.automatedevocations.pf2e = {
       "Forceful Hand":[
         {


### PR DESCRIPTION
The included default automated evocations currently don't support or handle translations at all.

This means:
1. Unnecessary code is run on non-english clients/games that will never work
2. In cases of name collisions, where translated actors have the same name as in english, they will be modified by the automations, and get english stuff added

Handling translations is not trivial and would need Babele for compendiums. For now, this PR just disables default automations if the language isn't english.