### PR TITLE
More compendium support: Support Pack UUID instead of in-world actor names

### DIFF
--- a/scripts/autoevocations/automatedevocations.js
+++ b/scripts/autoevocations/automatedevocations.js
@@ -24,10 +24,10 @@ Hooks.on("createChatMessage", async (chatMessage) => {
       for (let creature of creatures) {
         if (creature.level && spellLevel && creature.level >= spellLevel)
           continue;
-        let actor = game.actors.getName(creature.creature);
+        let actor = creature.creature.startsWith("Compendium.") ?  await fromUuid(creature.creature) : game.actors.getName(creature.creature);
         if (actor) {
           summonData.push({
-            id: actor.id,
+            id: creature.creature.startsWith("Compendium.") ? creature.creature : actor.id,
             number: creature.number,
             animation: creature.animation,
           });
@@ -54,10 +54,10 @@ Hooks.on("createChatMessage", async (chatMessage) => {
     for (let creature of creatures) {
       if (creature.level && spellLevel && creature.level >= spellLevel)
         continue;
-      let actor = game.actors.getName(creature.creature);
+      let actor = creature.creature.startsWith("Compendium.") ?  await fromUuid(creature.creature) : game.actors.getName(creature.creature);
       if (actor) {
         summonData.push({
-          id: actor.id,
+          id: creature.creature.startsWith("Compendium.") ? creature.creature : actor.id,
           number: creature.number,
           animation: creature.animation,
         });


### PR DESCRIPTION
Currently, compendium actors for summons are supported when using the summon manager on an actor.

Automated Evocations set via the binding manager or in the included evocations only support creature names though, so only in-world actors are supported. The code that reads those actually tries to fetch them via `fromUuid()` too already, but as it it currently only hands over the normal ID, that will never work for compendium actors.

With this change, the old way of using actor names is still supported, but if you use a Compendium UUID instead (starting with `Compendium.`), it will try to fetch that instead.