### PR TITLE
Fix errors, handle missing actors

### DIFF
--- a/languages/de.json
+++ b/languages/de.json
@@ -26,6 +26,10 @@
                 }
             }
         },
+        "errors": {
+            "summonActorMissing": "Der Akteur dieses Begleiters existiert nicht mehr.",
+            "summonCompendiumPlaceholderMissing": "Beschwörung von Akteuren aus Kompendien benötigen einen unverknüpften Akteur als Platzhalter in der Welt. Bitte unverknüpften Akteur anlegen."
+        },
         "actorSheetBtn": "Begleiter",
         "animations": {
             "fire": "Feuer",

--- a/languages/en.json
+++ b/languages/en.json
@@ -26,6 +26,10 @@
                 }
             }
         },
+        "errors": {
+            "summonActorMissing": "This companion refers to an actor that no longer exists.",
+            "summonCompendiumPlaceholderMissing": "Summoning compendium actors requires an unlinked placeholder actor in the world. Please create an unlinked actor."
+        },
         "actorSheetBtn": "Companions",
         "animations": {
             "fire": "Fire",

--- a/scripts/companionmanager.js
+++ b/scripts/companionmanager.js
@@ -113,6 +113,11 @@ class CompanionManager extends FormApplication {
       .val();
     const aId = event.currentTarget.dataset.aid;
     const actor = game.actors.get(aId) || await fromUuid(aId);
+    if (!actor) {
+      ui.notifications.info(game.i18n.localize("AE.errors.summonActorMissing"));
+      this.maximize();  
+      return;
+    }
     const duplicates = $(event.currentTarget.parentElement.parentElement)
       .find("#companion-number-val")
       .val();
@@ -142,7 +147,13 @@ class CompanionManager extends FormApplication {
     let isCompendiumActor = false;
     if (!tokenData.actor) {
       isCompendiumActor = true;
-      tokenData.updateSource({actorId: Array.from(game.actors).find(a => !a.prototypeToken?.actorLink).id})
+      const placeholder = game.actors.getName("Automated Evocations Placeholder") || Array.from(game.actors).find(a => !a.prototypeToken?.actorLink);
+      if (!placeholder) {
+        ui.notifications.info(game.i18n.localize("AE.errors.summonCompendiumPlaceholderMissing"));
+        this.maximize();  
+        return;
+      }
+      tokenData.updateSource({actorId: placeholder.id})
     }
     Hooks.on("preCreateToken", (tokenDoc, td) => {
       td ??= {};


### PR DESCRIPTION
This handles 2 errors and displays helpful messages instead of breaking:
1. Trying to summon an actor that no longer exists
2. Trying to summon a compendium actor while there is no unlinked actor in the world to use as placeholder

I've also slightly changed the placeholder behaviour, it now always tries to use an actor called `Automated Evocations Placeholder`, and if that does not exist, tries to use the first unlinked actor it can find, as before. This way, people can assign a specific placeholder actor in case the automatic behaviour results in conflicts with macros/modules.