### PR TITLE
Add flags on summons, copy token disposition, translate filter hint

### DIFF
--- a/languages/de.json
+++ b/languages/de.json
@@ -23,7 +23,8 @@
                 "confirm": {
                     "title": "Begleiter löschen",
                     "content": "<p>Sicher, dass dieser Begleiter gelöscht werden soll?</p>"
-                }
+                },
+                "filterHint": "Akteur in die Liste ziehen zum Hinzufügen."
             }
         },
         "actorSheetBtn": "Begleiter",

--- a/languages/de.json
+++ b/languages/de.json
@@ -68,6 +68,10 @@
             "restrictOwned": {
                 "title": "Nur Akteure in Besitz",
                 "hint": "Schränke die Begleiterliste auf Akteure ein, bei denen der Benutzer der Besitzer ist."
+            },
+            "copyDisposition": {
+                "title": "Gesinnung kopieren",
+                "hint": "Kopiert die Gesinnung der beschworenen Begleiter-Spielfiguren vom beschwörenden Akteur."
             }
         }
     }

--- a/languages/en.json
+++ b/languages/en.json
@@ -23,7 +23,8 @@
                 "confirm": {
                     "title": "Delete Companion",
                     "content": "<p>Are you sure you want to delete this companion?</p>"
-                }
+                },
+                "filterHint": "Drag and Drop an actor to add it to the list."
             }
         },
         "actorSheetBtn": "Companions",

--- a/languages/en.json
+++ b/languages/en.json
@@ -69,6 +69,10 @@
             "restrictOwned":{
                 "title": "Only Owned Actors",
                 "hint": "Restrict the companion list to only show owned companions actors."
+            },
+            "copyDisposition": {
+                "title": "Copy Disposition",
+                "hint": "Copies companion token disposition from summoning actor."
             }
         }
     }

--- a/scripts/companionmanager.js
+++ b/scripts/companionmanager.js
@@ -142,6 +142,15 @@ class CompanionManager extends FormApplication {
     if (!customTokenData.actor.flags) {
       customTokenData.actor.flags = {};
     }
+    if (!customTokenData.token) {
+      customTokenData.token = {};
+    }
+    if (game.settings.get(AECONSTS.MN, "copyDisposition")) {
+      const summonerDisposition = (this.caster || game?.user?.character || _token?.actor)?.prototypeToken?.disposition;
+      if (typeof summonerDisposition !== "undefined") {
+        customTokenData.token.disposition = summonerDisposition;
+      }
+    }
     customTokenData.actor.flags["automated-evocations"] = { "summonerID": (this.caster || game?.user?.character || _token?.actor)?.id || "", "spellLevel": this.spellLevel || 0 };
     customTokenData.elevation = posData?.flags?.levels?.elevation ?? _token?.document?.elevation ?? 0;
     customTokenData.elevation = parseFloat(customTokenData.elevation);

--- a/scripts/companionmanager.js
+++ b/scripts/companionmanager.js
@@ -44,7 +44,7 @@ class CompanionManager extends FormApplication {
   }
 
   async activateListeners(html) {
-    html.find("#companion-list").before(`<div class="searchbox"><input type="text" class="searchinput" placeholder="Drag and Drop an actor to add it to the list."></div>`)
+    html.find("#companion-list").before(`<div class="searchbox"><input type="text" class="searchinput" placeholder="${game.i18n.localize("AE.dialogs.companionManager.filterHint")}"></div>`)
     this.loadCompanions();
     html.on("input", ".searchinput", this._onSearch.bind(this));
     html.on("click", "#remove-companion", this._onRemoveCompanion.bind(this));

--- a/scripts/companionmanager.js
+++ b/scripts/companionmanager.js
@@ -136,6 +136,13 @@ class CompanionManager extends FormApplication {
     await this.wait(AECONSTS.animationFunctions[animation].time);
     //get custom data macro
     const customTokenData = await this.evaluateExpression(game.macros.getName(`AE_Companion_Macro(${actor.name})`)?.command, {summon: actor,spellLevel: this.spellLevel || 0, duplicates: duplicates, assignedActor: this.caster || game.user.character || _token.actor}) || {};
+    if (!customTokenData.actor) {
+      customTokenData.actor = {};
+    }
+    if (!customTokenData.actor.flags) {
+      customTokenData.actor.flags = {};
+    }
+    customTokenData.actor.flags["automated-evocations"] = { "summonerID": (this.caster || game?.user?.character || _token?.actor)?.id || "", "spellLevel": this.spellLevel || 0 };
     customTokenData.elevation = posData?.flags?.levels?.elevation ?? _token?.document?.elevation ?? 0;
     customTokenData.elevation = parseFloat(customTokenData.elevation);
     tokenData.elevation = customTokenData.elevation;

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -82,6 +82,14 @@ Hooks.once("init", async function () {
     type: Boolean,
     default: false,
   });
+  game.settings.register(AECONSTS.MN, "copyDisposition", {
+    name: game.i18n.localize(`AE.settings.copyDisposition.title`),
+    hint: game.i18n.localize(`AE.settings.copyDisposition.hint`),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true,
+  });
 });
 
 Hooks.once("ready", async function () {


### PR DESCRIPTION
1. Add flags with summon information on summoned actors (`summonerID`, `spellLevel`) so modules/scripts/macros can know that something is a summon and interact with it, similar to other summoning modules
2. Copy disposition for summoned tokens from the summoning actor by default, can be disabled via a new setting
3. Translate the "Drag & Drop actor to this list to add" hint in the companion manager UI

All 3 changes in separate commits for easier reviewing.

This includes the changes from https://github.com/theripper93/automated-evocations/pull/37 to avoid conflicts, so it supersedes that PR.